### PR TITLE
Filter review requests for only NamedUser's

### DIFF
--- a/reviewio/cli.py
+++ b/reviewio/cli.py
@@ -6,14 +6,14 @@ import click
 import requests
 from colorama import Fore
 from functools import reduce
-from github import Github, UnknownObjectException
+from github import Github, UnknownObjectException, NamedUser
 
 
 def extract_reviewers(pull_request, extract_weight):
     sources = [
         set([rev.user for rev in pull_request.get_reviews() if rev.state in ['APPROVED', 'REQUEST_CHANGES']]),
-        set([rev for rev in pull_request.get_review_requests()[0]]),
-        set([rev for rev in pull_request.get_review_requests()[1]])
+        set([rev for rev in pull_request.get_review_requests()[0] if isinstance(rev, NamedUser.NamedUser)]),
+        set([rev for rev in pull_request.get_review_requests()[1] if isinstance(rev, NamedUser.NamedUser)])
     ]
     points = extract_weight(pull_request)
     return {user: points for user in reduce(set.union, sources)}


### PR DESCRIPTION
Reviewio will crash when reading a PR that requested a review from a team.

For example, [this PR](https://github.com/gcivil-nyu-org/fall2019-cs-gy-6063-team-moonsurvivors/pull/302) has such a team request, and causes the following error in Reviewio:

```
$ reviewio show --state=all  gcivil-nyu-org/fall2019-cs-gy-6063-team-moonsurvivors
...
TypeError: unhashable type: 'Team'
```

As a fix, this change removes from consideration any "reviewers" that aren't vanilla Github users.