### PR TITLE
Modify review counting to favor users who comment on PRs

### DIFF
--- a/reviewio/cli.py
+++ b/reviewio/cli.py
@@ -11,12 +11,13 @@ from github import Github, UnknownObjectException, NamedUser
 
 def extract_reviewers(pull_request, extract_weight):
     sources = [
-        set([rev.user for rev in pull_request.get_reviews() if rev.state in ['APPROVED', 'REQUEST_CHANGES']]),
-        set([rev for rev in pull_request.get_review_requests()[0] if isinstance(rev, NamedUser.NamedUser)]),
-        set([rev for rev in pull_request.get_review_requests()[1] if isinstance(rev, NamedUser.NamedUser)])
+        set([rev.user for rev in pull_request.get_reviews()]),
+        set([rev.user for rev in pull_request.get_issue_comments()]),
+        set([rev.user for rev in pull_request.get_review_comments()])
     ]
+
     points = extract_weight(pull_request)
-    return {user: points for user in reduce(set.union, sources)}
+    return {user: points for user in reduce(set.union, sources) if user.login != pull_request.user.login}
 
 
 def extract_complex(pull_request):


### PR DESCRIPTION
Very cool tool! I wanted to propose an update to the way reviewers are counted. Let me know what you think.

Currently review counting is based on someone who creates a review or who someone who is requested as a reviewer. While someone may have been requested as a reviewer, it does not mean they actually reviewed the PR.

Additionally, someone may comment on a PR without officially making a review.

Modify the counting mechanism so that anyone who makes a comment or a review on a PR other than their own is counted as a reviewer.